### PR TITLE
Make faces inherit from standard emacs faces

### DIFF
--- a/typit.el
+++ b/typit.el
@@ -61,11 +61,11 @@
   "Face used to highlight current word.")
 
 (defface typit-correct-char
-  '((t (:foreground "spring green")))
+  '((t (:inherit success)))
   "Face used to color correctly typed characters.")
 
 (defface typit-wrong-char
-  '((t (:foreground "firebrick")))
+  '((t (:inherit error)))
   "Face used to color incorrectly typed characters.")
 
 (defface typit-statistic


### PR DESCRIPTION
The faces for correct and wrong chars clash a bit with the theme I'm using. This pr makes it so that those faces will always match the colors defined by the theme itself instead.
